### PR TITLE
テーマ切り替え機能の作成

### DIFF
--- a/lib/core/components/toggle_button.dart
+++ b/lib/core/components/toggle_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class ToggleButton extends StatefulWidget {
+  final Function(bool) isToggledCallback;
+  final bool isActive;
+  const ToggleButton({super.key, required this.isToggledCallback, this.isActive = false});
+
+  @override
+  State<ToggleButton> createState() => _ToggleButtonState();
+}
+
+class _ToggleButtonState extends State<ToggleButton> {
+  @override
+  Widget build(BuildContext context) {
+    bool isToggled = widget.isActive;
+    
+    return Switch(
+      value: isToggled,
+      activeColor: Colors.blue,
+      // ignore: deprecated_member_use
+      activeTrackColor: Colors.blue.withOpacity(0.5),
+      inactiveThumbColor: Colors.grey,
+      // ignore: deprecated_member_use
+      inactiveTrackColor: Colors.grey.withOpacity(0.5),
+      onChanged: (bool value) {
+        setState(() {
+          isToggled = value;
+          widget.isToggledCallback(isToggled);
+        });
+      },
+    );
+  }
+}

--- a/lib/features/settings_theme_switch/components/theme_settings_toggle.dart
+++ b/lib/features/settings_theme_switch/components/theme_settings_toggle.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/core/components/toggle_button.dart';
+import 'package:github_browser/features/settings_theme_switch/providers/theme_mode_provider.dart';
+
+class ThemeSettingToggle extends ConsumerStatefulWidget {
+  const ThemeSettingToggle({super.key});
+
+  @override
+  ConsumerState<ThemeSettingToggle> createState() => _ThemeSettingToggleState();
+}
+
+class _ThemeSettingToggleState extends ConsumerState<ThemeSettingToggle> {
+  @override
+  Widget build(BuildContext context) {
+    final themeMode = ref.watch(themeModeProvider);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text("settings_toggle_darkMode"),
+        ToggleButton(
+          isActive: themeMode == ThemeMode.light ? false : true,
+          isToggledCallback: (bool isToggled) {
+            ref.read(themeModeProvider.notifier).setThemeMode(
+              isToggled
+              ? ThemeMode.dark 
+              : ThemeMode.light
+            );
+          },
+        )
+      ],
+    );
+  }
+}

--- a/lib/features/settings_theme_switch/providers/theme_mode_provider.dart
+++ b/lib/features/settings_theme_switch/providers/theme_mode_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_theme_switch/providers/theme_repository_provider.dart';
+import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
+
+final themeModeProvider = StateNotifierProvider<ThemeModeNotifier, ThemeMode>((ref) {
+  final repository = ref.watch(themeRepositoryProvider);
+  return ThemeModeNotifier(repository);
+});
+
+class ThemeModeNotifier extends StateNotifier<ThemeMode> {
+  final ThemeRepository _repository;
+  
+  ThemeModeNotifier(this._repository) : super(ThemeMode.system) {
+    _loadThemeMode();
+  }
+  
+  Future<void> _loadThemeMode() async {
+    final mode = await _repository.loadThemeMode();
+    state = mode;
+  }
+  
+  Future<void> setThemeMode(ThemeMode mode) async {
+    await _repository.saveThemeMode(mode);
+    state = mode;
+  }
+}

--- a/lib/features/settings_theme_switch/providers/theme_repository_provider.dart
+++ b/lib/features/settings_theme_switch/providers/theme_repository_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
+
+final themeRepositoryProvider = Provider<ThemeRepository>((ref) {
+  return ThemeRepository();
+});

--- a/lib/features/settings_theme_switch/repositories/theme_repository.dart
+++ b/lib/features/settings_theme_switch/repositories/theme_repository.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeRepository {
+  static const String _key = 'theme_mode';
+  
+  Future<void> saveThemeMode(ThemeMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_key, mode.index);
+  }
+  
+  Future<ThemeMode> loadThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getInt(_key);
+    return value != null ? ThemeMode.values[value] : ThemeMode.system;
+  }
+}

--- a/test/unit/features/settings_switch_theme/providers/theme_mode_provider_test.dart
+++ b/test/unit/features/settings_switch_theme/providers/theme_mode_provider_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/settings_theme_switch/providers/theme_mode_provider.dart';
+import 'package:github_browser/features/settings_theme_switch/providers/theme_repository_provider.dart';
+import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateMocks([ThemeRepository])
+import 'theme_mode_provider_test.mocks.dart';
+
+void main() {
+  late MockThemeRepository mockRepository;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockRepository = MockThemeRepository();
+
+    when(mockRepository.loadThemeMode())
+        .thenAnswer((_) async => ThemeMode.dark);
+
+    container = ProviderContainer(
+      overrides: [
+        themeRepositoryProvider.overrideWithValue(mockRepository),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  test('初期状態はThemeMode.systemであること', () async {
+    
+    expect(container.read(themeModeProvider), ThemeMode.system);
+    
+    await Future.delayed(Duration.zero);
+    
+    verify(mockRepository.loadThemeMode()).called(1);
+  });
+
+  test('setThemeModeを呼び出すと、リポジトリが更新され状態が変わること', () async {
+    when(mockRepository.saveThemeMode(any))
+        .thenAnswer((_) async {});
+        
+    await container.read(themeModeProvider.notifier).setThemeMode(ThemeMode.dark);
+    
+    verify(mockRepository.saveThemeMode(ThemeMode.dark)).called(1);
+    
+    expect(container.read(themeModeProvider), ThemeMode.dark);
+  });
+}

--- a/test/unit/features/settings_switch_theme/repositories/theme_repository_test.dart
+++ b/test/unit/features/settings_switch_theme/repositories/theme_repository_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+///これはThemeModeをEntityとみなす。
+@GenerateMocks([])
+void main() {
+  late ThemeRepository themeRepository;
+
+  setUp(() {
+    themeRepository = ThemeRepository();
+  });
+
+  group('ThemeRepository', () {
+    test('SharedPreferencesに保存できること', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await themeRepository.saveThemeMode(ThemeMode.dark);
+
+      final prefs = await SharedPreferences.getInstance();
+      final savedValue = prefs.getInt('theme_mode');
+
+      expect(savedValue, ThemeMode.dark.index);
+    });
+
+    test('SharedPreferencesからテーマをロードできること', () async {
+      SharedPreferences.setMockInitialValues({'theme_mode': ThemeMode.light.index});
+      
+      final themeMode = await themeRepository.loadThemeMode();
+      
+      expect(themeMode, ThemeMode.light);
+    });
+
+    test('SharedPreferencesでエラーが発生した際にsystemを返すこと', () async {
+      SharedPreferences.setMockInitialValues({});
+      
+      final themeMode = await themeRepository.loadThemeMode();
+      
+      expect(themeMode, ThemeMode.system);
+    });
+
+    test('正常に保存できて、ロードできること', () async {
+      for (final mode in ThemeMode.values) {
+        SharedPreferences.setMockInitialValues({});
+        
+        await themeRepository.saveThemeMode(mode);
+        
+        final loadedMode = await themeRepository.loadThemeMode();
+        
+        expect(loadedMode, mode);
+      }
+    });
+  });
+}

--- a/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
+++ b/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/core/components/toggle_button.dart';
+import 'package:github_browser/features/settings_theme_switch/components/theme_settings_toggle.dart';
+import 'package:github_browser/features/settings_theme_switch/providers/theme_repository_provider.dart';
+import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateMocks([ThemeRepository])
+import 'theme_setting_toggle_test.mocks.dart';
+
+void main() {
+  late MockThemeRepository mockRepository;
+  late ProviderScope providerScope;
+
+  setUp(() {
+    mockRepository = MockThemeRepository();
+    
+    when(mockRepository.loadThemeMode())
+        .thenAnswer((_) async => ThemeMode.light);
+    when(mockRepository.saveThemeMode(any))
+        .thenAnswer((_) async {});
+
+    providerScope = ProviderScope(
+      overrides: [
+        themeRepositoryProvider.overrideWithValue(mockRepository),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: ThemeSettingToggle(),
+        ),
+      ),
+    );
+  });
+
+  testWidgets('ThemeSettingToggleが正しく表示されること', (WidgetTester tester) async {
+    await tester.pumpWidget(providerScope);
+    
+    await tester.pumpAndSettle();
+
+    expect(find.text("settings_toggle_darkMode"), findsOneWidget);
+    
+    expect(find.byType(ToggleButton), findsOneWidget);
+  });
+
+  testWidgets('初期状態でライトモードの場合、トグルがオフになっていること', (WidgetTester tester) async {
+    when(mockRepository.loadThemeMode())
+        .thenAnswer((_) async => ThemeMode.light);
+    
+    await tester.pumpWidget(providerScope);
+    await tester.pumpAndSettle();
+
+    final toggleFinder = find.byType(ToggleButton);
+    final ToggleButton toggle = tester.widget(toggleFinder);
+    
+    expect(toggle.isActive, false);
+  });
+
+  testWidgets('初期状態でダークモードの場合、トグルがオンになっていること', (WidgetTester tester) async {
+    when(mockRepository.loadThemeMode())
+        .thenAnswer((_) async => ThemeMode.dark);
+    
+    await tester.pumpWidget(providerScope);
+    await tester.pumpAndSettle();
+
+    final toggleFinder = find.byType(ToggleButton);
+    final ToggleButton toggle = tester.widget(toggleFinder);
+    
+    expect(toggle.isActive, true);
+  });
+
+  testWidgets('トグルをタップするとテーマモードが切り替わること', (WidgetTester tester) async {
+    when(mockRepository.loadThemeMode())
+        .thenAnswer((_) async => ThemeMode.light);
+    
+    await tester.pumpWidget(providerScope);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(ToggleButton));
+    await tester.pumpAndSettle();
+
+    verify(mockRepository.saveThemeMode(ThemeMode.dark)).called(1);
+
+    await tester.tap(find.byType(ToggleButton));
+    await tester.pumpAndSettle();
+
+    verify(mockRepository.saveThemeMode(ThemeMode.light)).called(1);
+  });
+}


### PR DESCRIPTION
## 対応Issue
https://github.com/Rerurate514/github_browser/issues/6

## 実施タスク
## 完了条件
- [x] ダークモードを有効化するトグルボタンを追加
- [x] その際にアプリ全体がFlutterデフォルトのダークモードになること
- [x] アプリがどのテーマになったかをShared_preferenceに保存すること 
- [x] アプリが起動された際に、事前に設定されたテーマになること

## 実施内容
- theme_settings_toggleコンポーネントの追加
- theme_repositoryクラスの作成
- theme_mode_providerの作成
- theme_repository_providerの作成
- 上三つに対してテストの作成

## 備考
theme_repository_providerはシンプルなファクトリであったので、テストは不要と判断。