### PR TITLE
言語切り替え機能の作成

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -37,7 +37,10 @@ jobs:
       run: flutter pub run build_runner build --delete-conflicting-outputs
 
     - name: Generate language_gen with build_runner
-      run: flutter gen-l10n
+      run: |
+        flutter pub get
+        flutter gen-l10n
+        flutter pub get
 
     - name: Run linter
       run: flutter analyze

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Generate code with build_runner
       run: flutter pub run build_runner build --delete-conflicting-outputs
 
+    - name: Generate language_gen with build_runner
+      run: flutter gen-l10n
+
     - name: Run linter
       run: flutter analyze
 

--- a/lib/core/exceptions/domain_exception.dart
+++ b/lib/core/exceptions/domain_exception.dart
@@ -1,0 +1,7 @@
+class DomainException implements Exception {
+  final String message;
+  DomainException(this.message);
+  
+  @override
+  String toString() => 'DomainException: $message';
+}

--- a/lib/features/repo_details/components/repository_info_card.dart
+++ b/lib/features/repo_details/components/repository_info_card.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class RepositoryInfoCard extends StatelessWidget {
   final Repository repository;
@@ -68,27 +69,27 @@ class RepositoryInfoCard extends StatelessWidget {
                     {
                       'icon': Icons.code, 
                       'value': repository.projectLanguage, 
-                      'label': "details_repository_language"
+                      'label': AppLocalizations.of(context)!.details_repository_language
                     },
                     {
                       'icon': Icons.star, 
                       'value': repository.starCount.toString(), 
-                      'label': "details_repository_stars"
+                      'label': AppLocalizations.of(context)!.details_repository_stars
                     },
                     {
                       'icon': Icons.remove_red_eye, 
                       'value': repository.watcherCount.toString(), 
-                      'label': "details_repository_watchers"
+                      'label': AppLocalizations.of(context)!.details_repository_watchers
                     },
                     {
                       'icon': Icons.call_split, 
                       'value': repository.forkCount.toString(), 
-                      'label': "details_repository_forks"
+                      'label': AppLocalizations.of(context)!.details_repository_forks
                     },
                     {
                       'icon': Icons.error_outline, 
                       'value': repository.issueCount.toString(), 
-                      'label': "details_repository_issues"
+                      'label': AppLocalizations.of(context)!.details_repository_issues
                     },
                   ];
                   

--- a/lib/features/repo_search/components/repo_result_view.dart
+++ b/lib/features/repo_search/components/repo_result_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:github_browser/features/repo_search/components/repo_list_item.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class RepositoryResultsView extends StatelessWidget {
   final bool isLoading;
@@ -37,8 +38,8 @@ class RepositoryResultsView extends StatelessWidget {
       return Center(
         child: Text(
           searchQuery.isEmpty 
-          ? "home_bar_title"
-          : "home_search_empty",
+          ? AppLocalizations.of(context)!.home_bar_title
+          : AppLocalizations.of(context)!.home_search_empty,
           style: const TextStyle(fontSize: 16),
         ),
       );

--- a/lib/features/settings_lang_switch/components/language_setting_buttons.dart
+++ b/lib/features/settings_lang_switch/components/language_setting_buttons.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/langs.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
+
+class LanguageSettingsButtons extends ConsumerStatefulWidget {
+  const LanguageSettingsButtons({super.key});
+
+  @override
+  LanguageSettingsButtonsState createState() => LanguageSettingsButtonsState();
+}
+
+class LanguageSettingsButtonsState extends ConsumerState<LanguageSettingsButtons> {
+  Language _selectedLanguage = Language.japanese;
+
+  void _changeLanguage(Language language) {
+    setState(() {
+      _selectedLanguage = language;
+    });
+
+    ref.read(languageProvider.notifier).setLanguage(language);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: ListView.builder(
+        itemCount: Langs.values.length,
+        itemBuilder: (context, index) {
+          final language = Language.fromCode(Langs.values[index].code);
+          return ListTile(
+            title: Text(language.name),
+            trailing: Radio<Language>(
+              value: language,
+              groupValue: _selectedLanguage,
+              onChanged: (value) => _changeLanguage(value!),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/settings_lang_switch/entities/langs.dart
+++ b/lib/features/settings_lang_switch/entities/langs.dart
@@ -1,0 +1,31 @@
+import 'dart:ui';
+
+enum Langs {
+  ja,
+  en
+}
+
+extension LangsToString on Langs {
+  String displayString(){
+    switch(this){
+      case Langs.ja: return "日本語";
+      case Langs.en: return "English";
+    }
+  }
+
+  String get code => name.toLowerCase();
+  String get fullString => '$this ($code)';
+}
+
+extension LangsToLocale on Langs {
+  Locale get locale{
+    switch(this){
+      case Langs.ja: return const Locale('ja', 'JP');
+      case Langs.en: return const Locale('en', 'US');
+    }
+  }
+}
+
+Langs? stringToLang(String langStr) {
+  return Langs.values.asNameMap()[langStr];
+}

--- a/lib/features/settings_lang_switch/entities/langs.dart
+++ b/lib/features/settings_lang_switch/entities/langs.dart
@@ -6,7 +6,7 @@ enum Langs {
 }
 
 extension LangsToString on Langs {
-  String displayString(){
+  String get name{
     switch(this){
       case Langs.ja: return "日本語";
       case Langs.en: return "English";

--- a/lib/features/settings_lang_switch/entities/language.dart
+++ b/lib/features/settings_lang_switch/entities/language.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 import 'package:github_browser/core/exceptions/domain_exception.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/langs.dart';
 
 class Language {
   final String code;
@@ -12,16 +13,16 @@ class Language {
     required this.locale,
   });
   
-  static const japanese = Language._(
-    code: 'ja',
-    name: '日本語',
-    locale: Locale('ja', 'JP'),
+  static final japanese = Language._(
+    code: Langs.ja.code,
+    name: Langs.ja.name,
+    locale: Langs.ja.locale,
   );
   
-  static const english = Language._(
-    code: 'en',
-    name: 'English',
-    locale: Locale('en', 'US'),
+  static final english = Language._(
+    code: Langs.en.code,
+    name: Langs.en.name,
+    locale: Langs.en.locale,
   );
   
   static List<Language> get allLanguages => [japanese, english];

--- a/lib/features/settings_lang_switch/entities/language.dart
+++ b/lib/features/settings_lang_switch/entities/language.dart
@@ -1,0 +1,51 @@
+import 'dart:ui';
+import 'package:github_browser/core/exceptions/domain_exception.dart';
+
+class Language {
+  final String code;
+  final String name;
+  final Locale locale;
+  
+  const Language._({
+    required this.code,
+    required this.name,
+    required this.locale,
+  });
+  
+  static const japanese = Language._(
+    code: 'ja',
+    name: '日本語',
+    locale: Locale('ja', 'JP'),
+  );
+  
+  static const english = Language._(
+    code: 'en',
+    name: 'English',
+    locale: Locale('en', 'US'),
+  );
+  
+  static List<Language> get allLanguages => [japanese, english];
+  
+  static Language fromCode(String code) {
+    final lowercaseCode = code.toLowerCase();
+    return allLanguages.firstWhere(
+      (language) => language.code.toLowerCase() == lowercaseCode,
+      orElse: () => throw DomainException('Unsupported language code: $code'),
+    );
+  }
+  
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Language &&
+      code == other.code &&
+      name == other.name &&
+      locale == other.locale;
+
+  @override
+  int get hashCode => Object.hash(code, name, locale);
+  
+  @override
+  String toString() => 'Language($code: $name)';
+}
+

--- a/lib/features/settings_lang_switch/providers/language_provider.dart
+++ b/lib/features/settings_lang_switch/providers/language_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_repositry_provider.dart';
+import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
+
+final languageProvider = StateNotifierProvider<LangNotifier, Language>((ref) {
+  final repository = ref.watch(languageRepositoryProvider);
+  return LangNotifier(repository);
+});
+
+class LangNotifier extends StateNotifier<Language> {
+  final LanguageRepository _repository;
+  
+  LangNotifier(this._repository) : super(Language.japanese) {
+    _loadLanguage();
+  }
+  
+  Future<void> _loadLanguage() async {
+    final lang = await _repository.loadLang();
+    state = lang;
+  }
+  
+  Future<void> setLanguage(Language lang) async {
+    await _repository.saveLang(lang);
+    state = lang;
+  }
+}

--- a/lib/features/settings_lang_switch/providers/language_repositry_provider.dart
+++ b/lib/features/settings_lang_switch/providers/language_repositry_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
+
+final languageRepositoryProvider = Provider<LanguageRepository>((ref) {
+  return LanguageRepository();
+});

--- a/lib/features/settings_lang_switch/repositories/language_repository.dart
+++ b/lib/features/settings_lang_switch/repositories/language_repository.dart
@@ -1,0 +1,20 @@
+import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LanguageRepository {
+  static const String _key = 'selected_language';
+  
+  Future<void> saveLang(Language language) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, Language.japanese.code);
+  }
+  
+  Future<Language> loadLang() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_key);
+    return 
+      value != null 
+      ? Language.fromCode(value)
+      : Language.english;
+  }
+}

--- a/lib/features/settings_lang_switch/repositories/language_repository.dart
+++ b/lib/features/settings_lang_switch/repositories/language_repository.dart
@@ -6,7 +6,7 @@ class LanguageRepository {
   
   Future<void> saveLang(Language language) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, Language.japanese.code);
+    await prefs.setString(_key, language.code);
   }
   
   Future<Language> loadLang() async {

--- a/lib/features/settings_theme_switch/components/theme_settings_toggle.dart
+++ b/lib/features/settings_theme_switch/components/theme_settings_toggle.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:github_browser/core/components/toggle_button.dart';
 import 'package:github_browser/features/settings_theme_switch/providers/theme_mode_provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class ThemeSettingToggle extends ConsumerStatefulWidget {
   const ThemeSettingToggle({super.key});
@@ -18,7 +19,7 @@ class _ThemeSettingToggleState extends ConsumerState<ThemeSettingToggle> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text("settings_toggle_darkMode"),
+        Text(AppLocalizations.of(context)!.settings_toggle_darkMode),
         ToggleButton(
           isActive: themeMode == ThemeMode.light ? false : true,
           isToggledCallback: (bool isToggled) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,40 @@
+{
+  "@@locale": "en",
+  "appTitle": "GitHub Browser",
+
+  "home_bar_title": "Search GitHub Repositories",
+  "home_search_hint": "Enter repository name",
+  "home_search_empty_navigate": "Please enter a search keyword",
+  "home_search_empty": "No search results found",
+
+  "details_bar_title": "Details",
+  
+  "details_repository_card_title": "Repository Information",
+  "details_repository_owner": "Owner",
+  "details_repository_name": "Repository Name",
+  "details_repository_description": "Description",
+  "details_repository_language": "Language",
+  "details_repository_stars": "Stars",
+  "details_repository_watchers": "Watchers",
+  "details_repository_forks": "Forks",
+  "details_repository_issues": "Issues",
+  "details_repository_created_at": "Created Date",
+  "details_repository_updated_at": "Updated Date",
+
+  "settings_bar_title": "Settings",
+  "settings_toggle_darkMode": "Enable Dark Mode",
+  "settings_select_lang": "Language Setting",
+
+  "error_repository_search_failed": "Error occurred while searching repository",
+  "error_details_fetch_failed": "Error occurred while fetching repository details",
+  "error_issue_fetch_failed": "Error occurred while getting issues count",
+  "error_apiRequest_failed": "GitHub API request failed",
+
+  "error_network": "Network error occurred",
+  "error_not_found": "Repository not found",
+  "error_general": "An error occurred. Please try again.",
+  
+  "button_retry": "Retry",
+  "button_view_on_github": "View on GitHub",
+  "button_share": "Share"
+}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,40 @@
+{
+  "@@locale": "ja",
+  "appTitle": "GitHub Browser",
+
+  "home_bar_title": "GitHub リポジトリ検索",
+  "home_search_hint": "リポジトリ名を入力してください",
+  "home_search_empty_navigate": "検索キーワードを入力してください",
+  "home_search_empty": "検索結果がありません",
+
+  "details_bar_title": "詳細",
+  
+  "details_repository_card_title": "リポジトリ情報",
+  "details_repository_owner": "所有者",
+  "details_repository_name": "リポジトリ名",
+  "details_repository_description": "説明",
+  "details_repository_language": "言語",
+  "details_repository_stars": "スター",
+  "details_repository_watchers": "ウォッチャー",
+  "details_repository_forks": "フォーク",
+  "details_repository_issues": "イシュー",
+  "details_repository_created_at": "作成日",
+  "details_repository_updated_at": "更新日",
+
+  "settings_bar_title": "設定",
+  "settings_toggle_darkMode": "ダークモードを有効化",
+  "settings_select_lang": "言語設定",
+
+  "error_repository_search_failed": "リポジトリ検索中にエラーが発生しました",
+  "error_details_fetch_failed": "リポジトリ詳細の取得中にエラーが発生しました",
+  "error_issue_fetch_failed": "Issue数の取得中にエラーが発生しました",
+  "error_apiRequest_failed": "GitHub API リクエストに失敗しました",
+
+  "error_network": "ネットワークエラーが発生しました",
+  "error_not_found": "リポジトリが見つかりませんでした",
+  "error_general": "エラーが発生しました。もう一度お試しください",
+  
+  "button_retry": "再試行",
+  "button_view_on_github": "GitHubで見る",
+  "button_share": "共有"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
 import 'package:github_browser/pages/search_page.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final locale = ref.watch(languageProvider).locale;
+
     return MaterialApp(
       title: 'Flutter Demo',
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        AppLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('ja', ''),
+        const Locale('en', ''),
+      ],
+      locale: locale,
+      localeResolutionCallback: (locale, supportedLocales) {
+        if (locale == null) return supportedLocales.first;
+
+        for (final supportedLocale in supportedLocales) {
+          if (supportedLocale.languageCode == locale.languageCode) {
+            return supportedLocale;
+          }
+        }
+
+        return supportedLocales.first;
+      },
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),

--- a/lib/pages/repo_detail_page.dart
+++ b/lib/pages/repo_detail_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:github_browser/features/repo_details/components/repository_info_card.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
-
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 class RepoDetailsPage extends StatefulWidget {
   final Repository repository;
 
@@ -16,7 +16,7 @@ class _RepoDetailsPageState extends State<RepoDetailsPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("details_bar_title"),
+        title: Text(AppLocalizations.of(context)!.details_bar_title),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -3,6 +3,7 @@ import 'package:github_browser/core/components/search_field.dart';
 import 'package:github_browser/features/repo_search/components/repo_result_view.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
 import 'package:github_browser/features/repo_search/repositories/github_repository.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class SearchPage extends StatefulWidget {
   const SearchPage({super.key});
@@ -60,7 +61,7 @@ class _SearchPageState extends State<SearchPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("home_bar_title"),
+        title: Text(AppLocalizations.of(context)!.home_bar_title),
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),
@@ -77,7 +78,7 @@ class _SearchPageState extends State<SearchPage> {
           children: [
             SearchField(
               onSearch: _handleSearch,
-              hint: "home_search_hint",
+              hint: AppLocalizations.of(context)!.home_search_hint,
             ),
             const SizedBox(height: 20),
             

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -246,6 +246,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -332,10 +337,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,9 +41,11 @@ dependencies:
   json_serializable: ^6.9.4
   flutter_riverpod: ^2.6.1
   shared_preferences: ^2.5.3
-  intl: ^0.20.2
   envied: ^1.1.1
   mockito: ^5.4.5
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/features/settings_switch_language/providers/language_provider_test.dart
+++ b/test/unit/features/settings_switch_language/providers/language_provider_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_repositry_provider.dart';
+import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateMocks([LanguageRepository])
+import 'language_provider_test.mocks.dart';
+
+void main() {
+  late MockLanguageRepository mockRepository;
+  late ProviderContainer container;
+
+  setUp(() {
+    mockRepository = MockLanguageRepository();
+
+    when(mockRepository.loadLang())
+        .thenAnswer((_) async => Language.japanese);
+
+    container = ProviderContainer(
+      overrides: [
+        languageRepositoryProvider.overrideWithValue(mockRepository),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  test('初期状態はLanguage.japaneseであること', () async {
+    
+    expect(container.read(languageProvider), Language.japanese);
+    
+    await Future.delayed(Duration.zero);
+    
+    verify(mockRepository.loadLang()).called(1);
+  });
+
+  test('setThemeModeを呼び出すと、リポジトリが更新され状態が変わること', () async {
+    when(mockRepository.saveLang(any))
+        .thenAnswer((_) async {});
+        
+    await container.read(languageProvider.notifier).setLanguage(Language.japanese);
+    
+    verify(mockRepository.saveLang(Language.japanese)).called(1);
+    
+    expect(container.read(languageProvider), Language.japanese);
+  });
+}

--- a/test/unit/features/settings_switch_language/repositories/language_repository_test.dart
+++ b/test/unit/features/settings_switch_language/repositories/language_repository_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/langs.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
+import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+@GenerateMocks([])
+void main() {
+  late LanguageRepository languageRepository;
+
+  setUp(() {
+    languageRepository = LanguageRepository();
+  });
+
+  group('LanguageRepository', () {
+    test('SharedPreferencesに保存できること', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      await languageRepository.saveLang(Language.japanese);
+
+      final prefs = await SharedPreferences.getInstance();
+      final savedValue = prefs.getString('selected_language');
+
+      expect(savedValue, Language.japanese.code);
+    });
+
+    test('SharedPreferencesから言語をロードできること', () async {
+      SharedPreferences.setMockInitialValues({
+        'selected_language': Language.japanese.code
+      });
+      
+      final lang = await languageRepository.loadLang();
+      
+      expect(lang, Language.japanese);
+    });
+
+    test('SharedPreferencesでエラーが発生した際にLanguage.englishを返すこと', () async {
+      SharedPreferences.setMockInitialValues({});
+      
+      final lang = await languageRepository.loadLang();
+      
+      expect(lang, Language.english);
+    });
+
+    test('正常に保存できて、ロードできること', () async {
+      for (final Langs value in Langs.values) {
+        SharedPreferences.setMockInitialValues({});
+        
+        final Language language = Language.fromCode(value.code);
+        
+        await languageRepository.saveLang(language);
+        
+        final loadedMode = await languageRepository.loadLang();
+        
+        expect(loadedMode, language);
+      }
+    });
+  });
+}

--- a/test/widget/features/settings_switch_language/components/language_setting_buttons_test.dart
+++ b/test/widget/features/settings_switch_language/components/language_setting_buttons_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_lang_switch/components/language_setting_buttons.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/langs.dart';
+import 'package:github_browser/features/settings_lang_switch/entities/language.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_repositry_provider.dart';
+import 'package:github_browser/features/settings_lang_switch/repositories/language_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateMocks([LanguageRepository])
+import 'language_setting_buttons_test.mocks.dart';
+
+void main() {
+  late MockLanguageRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockLanguageRepository();
+    when(mockRepository.loadLang()).thenAnswer((_) async => Language.japanese);
+  });
+
+  testWidgets('各言語のボタンが表示されること', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          languageRepositoryProvider.overrideWith((_) => mockRepository),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                LanguageSettingsButtons(),
+              ],
+            )
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('日本語'), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+  });
+
+  testWidgets('日本語がデフォルトで選択されていること', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          languageRepositoryProvider.overrideWith((_) => mockRepository),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                LanguageSettingsButtons(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final languageRadios = tester.widgetList<Radio<Language>>(find.byType(Radio<Language>));
+    final jaRadio = languageRadios.firstWhere(
+      (radio) => radio.value == Language.japanese
+    );
+    
+    expect(jaRadio.groupValue, equals(Language.japanese));
+  });
+  
+  testWidgets('ListViewに正しい言語数が含まれていること', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          languageRepositoryProvider.overrideWith((_) => mockRepository),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                LanguageSettingsButtons(),
+              ]
+            )
+          ),
+        ),
+      ),
+    );
+
+    final listTileCount = tester.widgetList(find.byType(ListTile)).length;
+    expect(listTileCount, equals(Langs.values.length));
+  });
+  
+  testWidgets('ListViewはコンテナ制約でスクロール可能でなければならないこと', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          languageRepositoryProvider.overrideWith((_) => mockRepository),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              height: 100,
+              child: Column(
+                children: [
+                  LanguageSettingsButtons(),
+                ]
+              )
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(ListView), findsOneWidget);
+    
+    final listView = find.byType(ListView);
+    await tester.drag(listView, const Offset(0, -200));
+    await tester.pump();
+  });
+  
+  testWidgets('ボタンをタップした際に言語が切り替わること', (WidgetTester tester) async {
+    when(mockRepository.saveLang(any)).thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          languageRepositoryProvider.overrideWith((_) => mockRepository),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                LanguageSettingsButtons(),
+              ]
+            )
+          ),
+        ),
+      ),
+    );
+
+    final initialRadios = tester.widgetList<Radio<Language>>(find.byType(Radio<Language>));
+    final initialJaRadio = initialRadios.firstWhere(
+      (radio) => radio.value == Language.japanese
+    );
+    expect(initialJaRadio.groupValue, equals(Language.japanese));
+    
+    await tester.tap(find.text('English'));
+    await tester.pump();
+    
+    final updatedRadios = tester.widgetList<Radio<Language>>(find.byType(Radio<Language>));
+    final updatedEnRadio = updatedRadios.firstWhere(
+      (radio) => radio.value == Language.english
+    );
+
+    expect(updatedEnRadio.value, Language.english);
+  });
+}

--- a/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
+++ b/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
@@ -40,7 +40,7 @@ void main() {
     
     await tester.pumpAndSettle();
 
-    expect(find.text("settings_toggle_darkMode"), findsOneWidget);
+    expect(find.text("ダークモードを有効化"), findsOneWidget);
     
     expect(find.byType(ToggleButton), findsOneWidget);
   });

--- a/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
+++ b/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
@@ -7,6 +7,12 @@ import 'package:github_browser/features/settings_theme_switch/providers/theme_re
 import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
+import 'package:github_browser/pages/search_page.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 @GenerateMocks([ThemeRepository])
 import 'theme_setting_toggle_test.mocks.dart';
@@ -28,6 +34,17 @@ void main() {
         themeRepositoryProvider.overrideWithValue(mockRepository),
       ],
       child: const MaterialApp(
+        localizationsDelegates: [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          AppLocalizations.delegate,
+        ],
+        supportedLocales: [
+          const Locale('ja', ''),
+          const Locale('en', ''),
+        ],
+        locale: Locale('ja', ''),
         home: Scaffold(
           body: ThemeSettingToggle(),
         ),

--- a/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
+++ b/test/widget/features/settings_switch_theme/components/theme_setting_toggle_test.dart
@@ -7,11 +7,7 @@ import 'package:github_browser/features/settings_theme_switch/providers/theme_re
 import 'package:github_browser/features/settings_theme_switch/repositories/theme_repository.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
-import 'package:github_browser/pages/search_page.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 @GenerateMocks([ThemeRepository])
@@ -41,8 +37,8 @@ void main() {
           AppLocalizations.delegate,
         ],
         supportedLocales: [
-          const Locale('ja', ''),
-          const Locale('en', ''),
+          Locale('ja', ''),
+          Locale('en', ''),
         ],
         locale: Locale('ja', ''),
         home: Scaffold(


### PR DESCRIPTION
## 対応Issue
https://github.com/Rerurate514/github_browser/issues/7

## 実施タスク
## 完了条件
- [x] 言語切り替えのラジオボタンを追加
- [x] アプリがどの言語になったかをShared_preferenceに保存すること
- [x] 言語切り替えを行うと即時にアプリの言語が変更されること
- [x] アプリが起動された際に、事前に設定された言語になること
- [x] 対応言語は以下に記す。
  - 日本語
  - English

## 実施内容
language_settings_buttonsコンポーネントの追加
language_repositoryクラスの作成
language_providerの作成
language_repository_providerの作成
上三つに対してテストの作成

## 備考
language_repository_providerはシンプルなファクトリであったので、テストは不要と判断。