### PR TITLE
設定画面の作成

### DIFF
--- a/lib/core/routes/page_router.dart
+++ b/lib/core/routes/page_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
 import 'package:github_browser/pages/repo_detail_page.dart';
+import 'package:github_browser/pages/settings_page.dart';
 
 class PageRouter {
   static void navigateDetailsPage(BuildContext context, Repository repository){
@@ -12,9 +13,9 @@ class PageRouter {
   }
 
   static void navigateSettingsPage(BuildContext context){
-    // Navigator.push(
-    //   context,
-    //   MaterialPageRoute(builder: (context) => const SettingsPage()),
-    // );
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const SettingsPage()),
+    );
   }
 }

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:github_browser/core/components/search_field.dart';
+import 'package:github_browser/core/routes/page_router.dart';
 import 'package:github_browser/features/repo_search/components/repo_result_view.dart';
 import 'package:github_browser/features/repo_search/entities/repository.dart';
 import 'package:github_browser/features/repo_search/repositories/github_repository.dart';
@@ -66,7 +67,7 @@ class _SearchPageState extends State<SearchPage> {
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {
-              //TODO ページルート -> settings_page
+              PageRouter.navigateSettingsPage(context);
             },
           ),
         ],

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:github_browser/features/settings_lang_switch/components/language_setting_buttons.dart';
+import 'package:github_browser/features/settings_theme_switch/components/theme_settings_toggle.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context)!.settings_bar_title),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            ThemeSettingToggle(),
+            LanguageSettingsButtons()
+          ],
+        )
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## 対応Issue
https://github.com/Rerurate514/github_browser/issues/3

## 実施タスク
- [x] 戻るボタンをタップすると検索画面に遷移すること
- [x] ダークモードを有効化するトグルボタンを追加
- [x] 言語切り替えのラジオボタンを追加

## 実施内容
- PageRouterに設定画面に遷移するメソッドを作成
- SettingsPagコンポーネントの作成

## 備考
