### PR TITLE
OSのシステムがdarkの場合とlightの場合で動作が同じになるように修正

### DIFF
--- a/lib/features/settings_theme_switch/repositories/theme_repository.dart
+++ b/lib/features/settings_theme_switch/repositories/theme_repository.dart
@@ -12,6 +12,6 @@ class ThemeRepository {
   Future<ThemeMode> loadThemeMode() async {
     final prefs = await SharedPreferences.getInstance();
     final value = prefs.getInt(_key);
-    return value != null ? ThemeMode.values[value] : ThemeMode.system;
+    return value != null ? ThemeMode.values[value] : ThemeMode.light;
   }
 }

--- a/test/unit/features/settings_switch_theme/repositories/theme_repository_test.dart
+++ b/test/unit/features/settings_switch_theme/repositories/theme_repository_test.dart
@@ -33,12 +33,12 @@ void main() {
       expect(themeMode, ThemeMode.light);
     });
 
-    test('SharedPreferencesでエラーが発生した際にsystemを返すこと', () async {
+    test('SharedPreferencesでエラーが発生した際にlightを返すこと', () async {
       SharedPreferences.setMockInitialValues({});
       
       final themeMode = await themeRepository.loadThemeMode();
       
-      expect(themeMode, ThemeMode.system);
+      expect(themeMode, ThemeMode.light);
     });
 
     test('正常に保存できて、ロードできること', () async {


### PR DESCRIPTION
## 実施タスク
- [x] システムテーマがlightとdarkの場合で初期動作を同期するように修正

## 実施内容
- SharedPreferencesにデータが存在しない場合に、ThemeMode.systemを返していたが、それをThemeMode.lightを返すように修正
- それに伴い、テストケースも変更

## 備考
