### PR TITLE
Github認証の作成

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -31,7 +31,11 @@ jobs:
 
     # リモートリポジトリでGitHub Secretsから.envファイルを動的に作成
     - name: Create .env
-      run: echo "API_KEY=${{ secrets.API_KEY }}" >> .env
+      run: |
+        echo "API_KEY=${{ secrets.API_KEY }}" >> .env
+        echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
+        echo "CLIENT_SECRET=${{ secrets.CLIENT_SECRET }}" >> .env
+        echo "REDIRECT_URL=${{ secrets.REDIRECT_URL }}" >> .env
 
     - name: Generate code with build_runner
       run: flutter pub run build_runner build --delete-conflicting-outputs

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="com.example.githubbrowser.auth" android:host="callback" /> <!-- 【1】 -->
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/core/env/env.dart
+++ b/lib/core/env/env.dart
@@ -6,4 +6,13 @@ part 'env.g.dart';
 abstract class Env {
   @EnviedField(varName: 'API_KEY', obfuscate: true)
   static String apiKey = _Env.apiKey;
+
+  @EnviedField(varName: 'CLIENT_ID')
+  static String clientId = _Env.clientId;
+
+  @EnviedField(varName: 'CLIENT_SECRET', obfuscate: true)
+  static String clientSecret = _Env.clientSecret;
+
+  @EnviedField(varName: 'REDIRECT_URL')
+  static String redirectUrl = _Env.redirectUrl;
 }

--- a/lib/features/github_auth/components/auth_wrapper.dart
+++ b/lib/features/github_auth/components/auth_wrapper.dart
@@ -7,16 +7,22 @@ import '../repositories/secure_repository.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class AuthWrapper extends StatefulWidget {
-  const AuthWrapper({super.key});
+  final GithubAuthRepository authRepository;
+  final GithubSecureRepository secureRepository;
+
+  AuthWrapper({
+    super.key,
+    GithubAuthRepository? authRepository,
+    GithubSecureRepository? secureRepository,
+  }) : 
+    authRepository = authRepository ?? GithubAuthRepository(),
+    secureRepository = secureRepository ?? GithubSecureRepository();
 
   @override
   AuthWrapperState createState() => AuthWrapperState();
 }
 
 class AuthWrapperState extends State<AuthWrapper> {
-  final GithubAuthRepository _authRepository = GithubAuthRepository();
-  final GithubSecureRepository _secureRepository = GithubSecureRepository();
-
   bool _isLoading = true;
   String? _authToken;
   String? _errorMessage;
@@ -29,7 +35,7 @@ class AuthWrapperState extends State<AuthWrapper> {
 
   Future<void> _checkAuth() async {
     try {
-      final token = await _secureRepository.getToken();
+      final token = await widget.secureRepository.getToken();
       setState(() {
         _authToken = token;
         _isLoading = false;
@@ -49,7 +55,7 @@ class AuthWrapperState extends State<AuthWrapper> {
     });
 
     try {
-      final result = await _authRepository.signIn();
+      final result = await widget.authRepository.signIn();
       
       setState(() {
         _isLoading = false;

--- a/lib/features/github_auth/components/auth_wrapper.dart
+++ b/lib/features/github_auth/components/auth_wrapper.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:github_browser/pages/search_page.dart';
+
+import '../repositories/github_auth_repository.dart';
+import '../repositories/secure_repository.dart';
+
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class AuthWrapper extends StatefulWidget {
+  const AuthWrapper({super.key});
+
+  @override
+  AuthWrapperState createState() => AuthWrapperState();
+}
+
+class AuthWrapperState extends State<AuthWrapper> {
+  final GithubAuthRepository _authRepository = GithubAuthRepository();
+  final GithubSecureRepository _secureRepository = GithubSecureRepository();
+
+  bool _isLoading = true;
+  String? _authToken;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkAuth();
+  }
+
+  Future<void> _checkAuth() async {
+    try {
+      final token = await _secureRepository.getToken();
+      setState(() {
+        _authToken = token;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _signIn() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final result = await _authRepository.signIn();
+      
+      setState(() {
+        _isLoading = false;
+        if (result.isSuccess) {
+          _authToken = result.token;
+        } else {
+          _errorMessage = result.errorMessage;
+        }
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _errorMessage = e.toString();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (_authToken != null) {
+      return SearchPage(token: _authToken!);
+    }
+
+    return SignInPage(
+      onSignIn: _signIn,
+      errorMessage: _errorMessage,
+    );
+  }
+}
+
+class SignInPage extends StatelessWidget {
+  final Future<void> Function() onSignIn;
+  final String? errorMessage;
+
+  const SignInPage({
+    super.key,
+    required this.onSignIn,
+    this.errorMessage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.code,
+                size: 80,
+                color: Colors.blue,
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                'GitHub Browser',
+                style: TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                AppLocalizations.of(context)!.auth_wrapper_app_use_explain,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 16,
+                ),
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton.icon(
+                onPressed: onSignIn,
+                icon: const Icon(Icons.login),
+                label: Text(AppLocalizations.of(context)!.appTitle),
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                  minimumSize: const Size(200, 0),
+                ),
+              ),
+              if (errorMessage != null) ...[
+                const SizedBox(height: 24),
+                Text(
+                  errorMessage!,
+                  style: const TextStyle(
+                    color: Colors.red,
+                    fontSize: 14,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/github_auth/entities/auth_result.dart
+++ b/lib/features/github_auth/entities/auth_result.dart
@@ -1,0 +1,27 @@
+class AuthResult {
+  final bool isSuccess;
+  final String? token;
+  final String? errorMessage;
+  final Map<String, dynamic>? userProfile;
+
+  AuthResult({
+    required this.isSuccess,
+    this.token,
+    this.errorMessage,
+    this.userProfile
+  });
+
+  factory AuthResult.success(String token) {
+    return AuthResult(
+      isSuccess: true,
+      token: token
+    );
+  }
+
+  factory AuthResult.failure(String errorMessage) {
+    return AuthResult(
+      isSuccess: false,
+      errorMessage: errorMessage,
+    );
+  }
+}

--- a/lib/features/github_auth/repositories/github_auth_repository.dart
+++ b/lib/features/github_auth/repositories/github_auth_repository.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';

--- a/lib/features/github_auth/repositories/github_auth_repository.dart
+++ b/lib/features/github_auth/repositories/github_auth_repository.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/material.dart';
+import 'package:github_browser/features/github_auth/entities/auth_result.dart';
+import 'package:oauth2/oauth2.dart';
+import 'package:github_browser/core/env/env.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+import 'package:github_browser/core/env/env.dart';
+
+class GithubAuthRepository {
+  final Uri authorizationEndpoint = Uri.parse('https://github.com/login/oauth/authorize');
+  final Uri tokenEndpoint = Uri.parse('https://github.com/login/oauth/access_token');
+  
+  final String clientId;
+  final String clientSecret;
+  final Uri redirectUrl;
+  
+  final List<String> scopes;
+  final File credentialsFile;
+  
+  final AppLinks _appLinks = AppLinks();
+  StreamSubscription? _linkSubscription;
+  
+  GithubAuthRepository({
+    String? clientId,
+    String? clientSecret,
+    String? redirectUrl,
+    List<String>? scopes,
+    String? credentialsPath,
+  }) : 
+    clientId = clientId ?? Env.clientId,
+    clientSecret = clientSecret ?? Env.clientSecret,
+    redirectUrl = Uri.parse(redirectUrl ?? Env.redirectUrl),
+    scopes = scopes ?? ['repo', 'user'],
+    credentialsFile = File(credentialsPath ?? 'credentials.json');
+  
+  Future<AuthResult> signIn() async {
+
+    if(Env.apiKey != ""){
+      return AuthResult.success(Env.apiKey);
+    }
+
+    try {
+      final grant = AuthorizationCodeGrant(
+        clientId, 
+        authorizationEndpoint, 
+        tokenEndpoint,
+        secret: clientSecret,
+        basicAuth: false,
+      );
+
+      debugPrint('使用するリダイレクトURL: $redirectUrl');
+      final authorizationUrl = grant.getAuthorizationUrl(redirectUrl, scopes: scopes);
+      debugPrint('GitHub認証URL: $authorizationUrl');
+
+      await _redirectToBrowser(authorizationUrl);
+      
+      debugPrint('リダイレクトを待機中...');
+      final responseUrl = await _listenForAppLink();
+      debugPrint('リダイレクトURLを受信: $responseUrl');
+      
+      debugPrint('認証レスポンスを処理中...');
+      debugPrint('レスポンスパラメータ: ${responseUrl.queryParameters}');
+
+      final code = responseUrl.queryParameters['code'];
+      if (code != null) {
+        final response = await http.post(
+          tokenEndpoint,
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: {
+            'client_id': clientId,
+            'client_secret': clientSecret,
+            'code': code,
+            'redirect_uri': redirectUrl.toString(),
+          },
+        );
+        
+        if (response.statusCode == 200) {
+          final data = json.decode(response.body);
+          final accessToken = data['access_token'];
+          
+          return AuthResult.success(accessToken);
+        } else {
+          throw Exception('Failed to get access token: ${response.body}');
+        }
+      }
+    } catch (e, stackTrace) {
+      debugPrint('認証プロセス中にエラーが発生しました: $e');
+      debugPrint('スタックトレース: $stackTrace');
+    } finally {
+      await _linkSubscription?.cancel();
+      _linkSubscription = null;
+    }
+
+    return AuthResult.failure("");
+  }
+  
+  Future<Uri> _listenForAppLink() async {
+    final completer = Completer<Uri>();
+    
+    try {
+      final initialLink = await _appLinks.getInitialLink();
+      if (initialLink != null && initialLink.queryParameters.containsKey('code')) {
+        debugPrint('初期App Linkからコードを検出: ${initialLink.queryParameters['code']}');
+        completer.complete(initialLink);
+        return completer.future;
+      }
+    } catch (e) {
+      debugPrint('初期App Linkの取得エラー: $e');
+    }
+    
+    _linkSubscription = _appLinks.uriLinkStream.listen((Uri uri) {
+      if (!completer.isCompleted && uri.queryParameters.containsKey('code')) {
+        debugPrint('App Linkからコードを検出: ${uri.queryParameters['code']}');
+        completer.complete(uri);
+      }
+    }, onError: (error) {
+      debugPrint('App Linkエラー: $error');
+      if (!completer.isCompleted) {
+        completer.completeError(error);
+      }
+    });
+    
+    return completer.future;
+  }
+  
+  Future<void> _redirectToBrowser(Uri url) async {
+    debugPrint('以下のURLをブラウザで開いてGitHubにログインしてください:');
+    debugPrint(url.toString());
+
+    await launchUrl(
+      url,
+      mode: LaunchMode.externalApplication,
+    );
+  }
+}

--- a/lib/features/github_auth/repositories/github_auth_repository.dart
+++ b/lib/features/github_auth/repositories/github_auth_repository.dart
@@ -8,10 +8,8 @@ import 'package:oauth2/oauth2.dart';
 import 'package:github_browser/core/env/env.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'package:http/http.dart' as http;
+import 'package:http/http.dart';
 import 'dart:convert';
-
-import 'package:github_browser/core/env/env.dart';
 
 class GithubAuthRepository {
   final Uri authorizationEndpoint = Uri.parse('https://github.com/login/oauth/authorize');
@@ -70,7 +68,7 @@ class GithubAuthRepository {
 
       final code = responseUrl.queryParameters['code'];
       if (code != null) {
-        final response = await http.post(
+        final response = await post(
           tokenEndpoint,
           headers: {
             'Accept': 'application/json',

--- a/lib/features/github_auth/repositories/github_auth_repository.dart
+++ b/lib/features/github_auth/repositories/github_auth_repository.dart
@@ -20,7 +20,6 @@ class GithubAuthRepository {
   final Uri redirectUrl;
   
   final List<String> scopes;
-  final File credentialsFile;
 
   final AppLinks appLinks;
   final UrlLauncher urlLauncher;
@@ -32,7 +31,6 @@ class GithubAuthRepository {
     String? clientSecret,
     String? redirectUrl,
     List<String>? scopes,
-    String? credentialsPath,
     AppLinks? appLinks,
     UrlLauncher? urlLauncher,
   }) : 
@@ -40,7 +38,6 @@ class GithubAuthRepository {
     clientSecret = clientSecret ?? Env.clientSecret,
     redirectUrl = Uri.parse(redirectUrl ?? Env.redirectUrl),
     scopes = scopes ?? ['repo', 'user'],
-    credentialsFile = File(credentialsPath ?? 'credentials.json'),
     appLinks = appLinks ?? AppLinks(),
     urlLauncher = urlLauncher ?? DefaultUrlLauncher();
   

--- a/lib/features/github_auth/repositories/secure_repository.dart
+++ b/lib/features/github_auth/repositories/secure_repository.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+
+class GithubSecureRepository{
+  final FlutterSecureStorage _secureStorage;
+  static const String _tokenKey = 'github_auth_token';
+
+  GithubSecureRepository(): _secureStorage = const FlutterSecureStorage();
+
+
+  Future<void> saveToken(String token) async {
+    await _secureStorage.write(key: _tokenKey, value: token);
+  }
+
+  Future<String?> getToken() async {
+    return await _secureStorage.read(key: _tokenKey);
+  }
+
+  Future<void> deleteToken() async {
+    await _secureStorage.delete(key: _tokenKey);
+  }
+}

--- a/lib/features/github_auth/repositories/secure_repository.dart
+++ b/lib/features/github_auth/repositories/secure_repository.dart
@@ -5,7 +5,8 @@ class GithubSecureRepository{
   final FlutterSecureStorage _secureStorage;
   static const String _tokenKey = 'github_auth_token';
 
-  GithubSecureRepository(): _secureStorage = const FlutterSecureStorage();
+  GithubSecureRepository({FlutterSecureStorage? storage})
+    : _secureStorage = storage ?? const FlutterSecureStorage();
 
 
   Future<void> saveToken(String token) async {

--- a/lib/features/repo_search/repositories/github_repository.dart
+++ b/lib/features/repo_search/repositories/github_repository.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:github_browser/core/env/env.dart';
 
 class GitHubRepository {
-  final String _apiToken = Env.apiKey;
+  final String _apiToken;
 
   final String _baseUrl;
   final http.Client _httpClient;
@@ -15,9 +15,11 @@ class GitHubRepository {
   GitHubRepository({
     http.Client? httpClient,
     String baseUrl = 'https://api.github.com',
+    String? apiToken
   })  : 
         _httpClient = httpClient ?? http.Client(),
-        _baseUrl = baseUrl;
+        _baseUrl = baseUrl,
+        _apiToken = apiToken ?? Env.apiKey;
 
   Future<List<Repository>> searchRepositories(
     String query, {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -25,6 +25,8 @@
   "settings_toggle_darkMode": "Enable Dark Mode",
   "settings_select_lang": "Language Setting",
 
+    "auth_wrapper_app_use_explain": "To use the app, you must sign in with your GitHub account.",
+
   "error_repository_search_failed": "Error occurred while searching repository",
   "error_details_fetch_failed": "Error occurred while fetching repository details",
   "error_issue_fetch_failed": "Error occurred while getting issues count",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -25,6 +25,8 @@
   "settings_toggle_darkMode": "ダークモードを有効化",
   "settings_select_lang": "言語設定",
 
+  "auth_wrapper_app_use_explain": "アプリをご利用いただくには、GitHubアカウントでのサインインが必要です。",
+
   "error_repository_search_failed": "リポジトリ検索中にエラーが発生しました",
   "error_details_fetch_failed": "リポジトリ詳細の取得中にエラーが発生しました",
   "error_issue_fetch_failed": "Issue数の取得中にエラーが発生しました",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:github_browser/features/github_auth/components/auth_wrapper.dart';
 import 'package:github_browser/features/settings_lang_switch/providers/language_provider.dart';
 import 'package:github_browser/features/settings_theme_switch/providers/theme_mode_provider.dart';
-import 'package:github_browser/pages/search_page.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() {
@@ -51,7 +51,7 @@ class MyApp extends ConsumerWidget {
         brightness: Brightness.dark,
         primarySwatch: Colors.blue,
       ),
-      home: SearchPage()
+      home: AuthWrapper()
     );
   }
 }

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -7,20 +7,27 @@ import 'package:github_browser/features/repo_search/repositories/github_reposito
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class SearchPage extends StatefulWidget {
-  const SearchPage({super.key});
+  final String token;
+  const SearchPage({super.key, required this.token});
 
   @override
-  State<SearchPage> createState() => _SearchPageState();
+  // ignore: no_logic_in_create_state
+  State<SearchPage> createState() => SearchPageState(token);
 }
 
-class _SearchPageState extends State<SearchPage> {
+class SearchPageState extends State<SearchPage> {
   String _searchQuery = '';
   bool _isLoading = false;
   List<Repository> _searchResults = [];
   // ignore: unused_field
   String? _errorMessage;
   
-  final GitHubRepository _repository = GitHubRepository();
+  late final GitHubRepository _repository;
+
+  //ここでtokenをwidget.token経由で渡そうとすると、
+  //late final フィールドの初期化タイミングの問題が発生するためコンストラクタで
+  //直接渡す方式を採用
+  SearchPageState(String token) : _repository = GitHubRepository(apiToken: token);
   
   @override
   void dispose() {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  gtk
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_secure_storage_macos
+import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import flutter_secure_storage_macos
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import flutter_secure_storage_macos
 import path_provider_foundation
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -259,6 +259,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9f3dd2ac3b6875b0fde5b04734789c3ef35ba3965c18e99dd564a7a2f8056df6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -802,6 +802,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "1d0eae19bd7606ef60fe69ef3b312a437a16549476c42321d5dc1506c9ca3bf4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.15"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -453,6 +453,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.5"
+  oauth2:
+    dependency: "direct main"
+    description:
+      name: oauth2
+      sha256: c84470642cbb2bec450ccab2f8520c079cd1ca546a76ffd5c40589e07f4e8bf4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -802,6 +802,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uni_links:
+    dependency: "direct main"
+    description:
+      name: uni_links
+      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
+  uni_links_platform_interface:
+    dependency: transitive
+    description:
+      name: uni_links_platform_interface
+      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  uni_links_web:
+    dependency: transitive
+    description:
+      name: uni_links_web
+      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -263,10 +263,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9f3dd2ac3b6875b0fde5b04734789c3ef35ba3965c18e99dd564a7a2f8056df6"
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: bf7404619d7ab5c0a1151d7c4e802edad8f33535abfbeff2f9e1fe1274e2d705
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -361,10 +401,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
@@ -485,6 +525,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "0ca7359dad67fd7063cb2892ab0c0737b2daafd807cf1acecd62374c8fae6c12"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.16"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -786,6 +850,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.12.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "85ed8fc1d25a76475914fff28cc994653bd900bc2c26e4b57a49e097febb54ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   args:
     dependency: transitive
     description:
@@ -357,6 +389,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   http:
     dependency: transitive
     description:
@@ -802,30 +842,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  uni_links:
-    dependency: "direct main"
-    description:
-      name: uni_links
-      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.1"
-  uni_links_platform_interface:
-    dependency: transitive
-    description:
-      name: uni_links_platform_interface
-      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  uni_links_web:
-    dependency: transitive
-    description:
-      name: uni_links_web
-      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   intl: ^0.19.0
   oauth2: ^2.0.3
   flutter_secure_storage: ^9.2.4
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   oauth2: ^2.0.3
   flutter_secure_storage: ^9.2.4
   url_launcher: ^6.3.1
-  uni_links: ^0.5.1
+  app_links: ^6.4.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.19.0
+  oauth2: ^2.0.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   oauth2: ^2.0.3
   flutter_secure_storage: ^9.2.4
   url_launcher: ^6.3.1
+  uni_links: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
     sdk: flutter
   intl: ^0.19.0
   oauth2: ^2.0.3
-  flutter_secure_storage: ^4.2.1
+  flutter_secure_storage: ^9.2.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
     sdk: flutter
   intl: ^0.19.0
   oauth2: ^2.0.3
+  flutter_secure_storage: ^4.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/features/github_auth/entities/auth_result_test.dart
+++ b/test/unit/features/github_auth/entities/auth_result_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/github_auth/entities/auth_result.dart';
+
+void main() {
+  group('AuthResult', () {
+    test('必須パラメータでインスタンスを作成できること', () {
+      final result = AuthResult(isSuccess: true);
+
+      expect(result.isSuccess, true);
+      expect(result.token, isNull);
+      expect(result.errorMessage, isNull);
+      expect(result.userProfile, isNull);
+    });
+
+    test('すべてのパラメータでインスタンスを作成できること', () {
+      final Map<String, dynamic> userProfile = {
+        'id': 1,
+        'name': 'Test User',
+        'email': 'test@example.com'
+      };
+
+      final result = AuthResult(
+        isSuccess: true,
+        token: 'test_token',
+        errorMessage: 'test_error',
+        userProfile: userProfile
+      );
+
+      expect(result.isSuccess, true);
+      expect(result.token, 'test_token');
+      expect(result.errorMessage, 'test_error');
+      expect(result.userProfile, userProfile);
+    });
+
+    group('factory constructors', () {
+      test('AuthResult.successはトークン付きの成功インスタンスを作成すること', () {
+        final result = AuthResult.success('test_token');
+
+        expect(result.isSuccess, true);
+        expect(result.token, 'test_token');
+        expect(result.errorMessage, isNull);
+        expect(result.userProfile, isNull);
+      });
+
+      test('AuthResult.failureはエラーメッセージ付きの失敗インスタンスを作成すること', () {
+        final result = AuthResult.failure('Authentication failed');
+
+        expect(result.isSuccess, false);
+        expect(result.token, isNull);
+        expect(result.errorMessage, 'Authentication failed');
+        expect(result.userProfile, isNull);
+      });
+    });
+  });
+}

--- a/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
@@ -27,7 +27,6 @@ void main() {
   const testClientSecret = 'test_client_secret';
   const testRedirectUrl = 'com.example://callback';
   final testScopes = ['repo', 'user'];
-  const testCredentialsPath = 'test_credentials.json';
   const testAccessToken = 'test_access_token';
   
   setUp(() {

--- a/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
@@ -1,0 +1,384 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/core/env/env.dart';
+import 'package:github_browser/features/github_auth/entities/auth_result.dart';
+import 'package:github_browser/features/github_auth/repositories/github_auth_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+@GenerateMocks([AppLinks, UrlLauncher, File, http.Client])
+import 'github_auth_repository_test.mocks.dart';
+
+void main() {
+  late GithubAuthRepository repository;
+  late MockAppLinks mockAppLinks;
+  late MockUrlLauncher mockUrlLauncher;
+  
+  const testClientId = 'test_client_id';
+  const testClientSecret = 'test_client_secret';
+  const testRedirectUrl = 'com.example://callback';
+  final testScopes = ['repo', 'user'];
+  const testCredentialsPath = 'test_credentials.json';
+  const testAccessToken = 'test_access_token';
+  
+  setUp(() {
+    mockAppLinks = MockAppLinks();
+    mockUrlLauncher = MockUrlLauncher();
+    
+    when(mockUrlLauncher.launch(any, mode: anyNamed('mode')))
+        .thenAnswer((_) async => true);
+    
+    final streamController = StreamController<Uri>();
+    when(mockAppLinks.uriLinkStream).thenAnswer((_) => streamController.stream);
+    when(mockAppLinks.getInitialLink()).thenAnswer((_) async => null);
+    
+    repository = GithubAuthRepository(
+      clientId: testClientId,
+      clientSecret: testClientSecret,
+      redirectUrl: testRedirectUrl,
+      scopes: testScopes,
+      credentialsPath: testCredentialsPath,
+      appLinks: mockAppLinks,
+      urlLauncher: mockUrlLauncher,
+    );
+  });
+  
+  group('GithubAuthRepository', () {
+    test('正しい値で初期化されること', () {
+      expect(repository.clientId, testClientId);
+      expect(repository.clientSecret, testClientSecret);
+      expect(repository.redirectUrl, Uri.parse(testRedirectUrl));
+      expect(repository.scopes, testScopes);
+      expect(repository.credentialsFile, isA<File>());
+      expect(repository.appLinks, mockAppLinks);
+    });
+    
+    test('値が提供されない場合にデフォルト値を使用すること', () {
+      repository = GithubAuthRepository();
+      
+      expect(repository.clientId, Env.clientId);
+      expect(repository.clientSecret, Env.clientSecret);
+      expect(repository.redirectUrl, Uri.parse(Env.redirectUrl));
+      expect(repository.scopes, ['repo', 'user']);
+      expect(repository.credentialsFile, isA<File>());
+      expect(repository.appLinks, isA<AppLinks>());
+    });
+    
+    test('EnvにAPIキーが存在する場合に直接APIキーを返すこと', () async {
+      const testApiKey = 'test_api_key';
+    
+      final testRepository = _TestGithubAuthRepository(
+        clientId: testClientId,
+        clientSecret: testClientSecret,
+        redirectUrl: testRedirectUrl,
+        scopes: testScopes,
+        credentialsPath: testCredentialsPath,
+        appLinks: mockAppLinks,
+        urlLauncher: mockUrlLauncher,
+        apiKey: testApiKey,
+      );
+      
+      final result = await testRepository.signIn();
+      
+      expect(result, isA<AuthResult>());
+      expect(result.isSuccess, true);
+      expect(result.token, testApiKey);
+    
+      verifyNever(mockUrlLauncher.launch(any, mode: anyNamed('mode')));
+    });
+    
+    test('GitHubで認証し、アクセストークンを返すこと', () async {
+      when(mockAppLinks.getInitialLink()).thenAnswer((_) async => null);
+      
+      final redirectUriWithCode = Uri.parse('$testRedirectUrl?code=test_code');
+      
+      final streamController = StreamController<Uri>();
+      when(mockAppLinks.uriLinkStream).thenAnswer((_) => streamController.stream);
+      
+      final httpMock = (request) async {
+        if (request.url.toString() == 'https://github.com/login/oauth/access_token') {
+          return http.Response(
+            '{"access_token": "$testAccessToken", "token_type": "bearer", "scope": "repo,user"}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('Not found', 404);
+      };
+      
+      final testRepository = _TestGithubAuthRepositoryWithHttpMock(
+        clientId: testClientId,
+        clientSecret: testClientSecret,
+        redirectUrl: testRedirectUrl,
+        scopes: testScopes,
+        credentialsPath: testCredentialsPath,
+        appLinks: mockAppLinks,
+        urlLauncher: mockUrlLauncher,
+        httpMock: httpMock,
+      );
+      
+      final futureResult = testRepository.signIn();
+      
+      verify(mockUrlLauncher.launch(any, mode: anyNamed('mode'))).called(1);
+      
+      streamController.add(redirectUriWithCode);
+      
+      final result = await futureResult;
+      
+      expect(result.isSuccess, true);
+      expect(result.token, testAccessToken);
+
+      
+      await streamController.close();
+    });
+    
+    test('アクセストークンの取得に失敗した場合にエラーを処理すること', () async {
+      when(mockAppLinks.getInitialLink()).thenAnswer((_) async => null);
+      
+      final redirectUriWithCode = Uri.parse('$testRedirectUrl?code=test_code');
+      
+      final streamController = StreamController<Uri>();
+      when(mockAppLinks.uriLinkStream).thenAnswer((_) => streamController.stream);
+      
+      final httpMock = (request) async {
+        if (request.url.toString() == 'https://github.com/login/oauth/access_token') {
+          return http.Response(
+            '{"error": "bad_verification_code"}',
+            400,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('Not found', 404);
+      };
+      
+      final testRepository = _TestGithubAuthRepositoryWithHttpMock(
+        clientId: testClientId,
+        clientSecret: testClientSecret,
+        redirectUrl: testRedirectUrl,
+        scopes: testScopes,
+        credentialsPath: testCredentialsPath,
+        appLinks: mockAppLinks,
+        urlLauncher: mockUrlLauncher,
+        httpMock: httpMock,
+      );
+      
+      final futureResult = testRepository.signIn();
+      
+      verify(mockUrlLauncher.launch(any, mode: anyNamed('mode'))).called(1);
+      
+      streamController.add(redirectUriWithCode);
+      
+      final result = await futureResult;
+      
+      expect(result.isSuccess, false);
+      
+      await streamController.close();
+    });
+    
+    test('初期リンクにコードが含まれている場合を処理すること', () async {
+      final initialLink = Uri.parse('$testRedirectUrl?code=initial_code');
+      when(mockAppLinks.getInitialLink()).thenAnswer((_) async => initialLink);
+      
+      final httpMock = (request) async {
+        if (request.url.toString() == 'https://github.com/login/oauth/access_token') {
+          return http.Response(
+            '{"access_token": "$testAccessToken", "token_type": "bearer", "scope": "repo,user"}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('Not found', 404);
+      };
+      
+      final testRepository = _TestGithubAuthRepositoryWithHttpMock(
+        clientId: testClientId,
+        clientSecret: testClientSecret,
+        redirectUrl: testRedirectUrl,
+        scopes: testScopes,
+        credentialsPath: testCredentialsPath,
+        appLinks: mockAppLinks,
+        urlLauncher: mockUrlLauncher,
+        httpMock: httpMock,
+      );
+      
+      
+      final result = await testRepository.signIn();
+
+      expect(result.isSuccess, true);
+      expect(result.token, testAccessToken);
+      
+      verify(mockUrlLauncher.launch(any, mode: anyNamed('mode'))).called(1);
+    });
+  });
+}
+
+class _TestGithubAuthRepository extends GithubAuthRepository {
+  final String apiKey;
+  
+  _TestGithubAuthRepository({
+    required String clientId,
+    required String clientSecret,
+    required String redirectUrl,
+    required List<String> scopes,
+    required String credentialsPath,
+    required AppLinks appLinks,
+    required UrlLauncher urlLauncher,
+    required this.apiKey,
+  }) : super(
+    clientId: clientId,
+    clientSecret: clientSecret,
+    redirectUrl: redirectUrl,
+    scopes: scopes,
+    credentialsPath: credentialsPath,
+    appLinks: appLinks,
+    urlLauncher: urlLauncher,
+  );
+  
+  @override
+  Future<AuthResult> signIn() async {
+    if (apiKey != "") {
+      return AuthResult.success(apiKey);
+    }
+    return super.signIn();
+  }
+}
+
+class _TestGithubAuthRepositoryWithHttpMock extends GithubAuthRepository {
+  final Future<http.Response> Function(http.Request) httpMock;
+  StreamSubscription? _linkSubscription;
+  
+  _TestGithubAuthRepositoryWithHttpMock({
+    required String clientId,
+    required String clientSecret,
+    required String redirectUrl,
+    required List<String> scopes,
+    required String credentialsPath,
+    required AppLinks appLinks,
+    required UrlLauncher urlLauncher,
+    required this.httpMock,
+  }) : super(
+    clientId: clientId,
+    clientSecret: clientSecret,
+    redirectUrl: redirectUrl,
+    scopes: scopes,
+    credentialsPath: credentialsPath,
+    appLinks: appLinks,
+    urlLauncher: urlLauncher,
+  );
+  
+  @override
+  Future<AuthResult> signIn() async {
+    try {
+      final grant = AuthorizationCodeGrant(
+        clientId, 
+        authorizationEndpoint, 
+        tokenEndpoint,
+        secret: clientSecret,
+        basicAuth: false,
+        httpClient: _MockHttpClient(httpMock),
+      );
+
+      final authorizationUrl = grant.getAuthorizationUrl(redirectUrl, scopes: scopes);
+
+      await _redirectToBrowser(authorizationUrl);
+      
+      final responseUrl = await _listenForAppLink();
+      
+      final code = responseUrl.queryParameters['code'];
+      if (code == null) return AuthResult.failure("responseUrl.queryParameters code is null");
+      
+      final request = http.Request('POST', tokenEndpoint);
+      request.headers['Accept'] = 'application/json';
+      request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      request.bodyFields = {
+        'client_id': clientId,
+        'client_secret': clientSecret,
+        'code': code,
+        'redirect_uri': redirectUrl.toString(),
+      };
+      
+      final response = await httpMock(request);
+      
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final accessToken = data['access_token'];
+        
+        return AuthResult.success(accessToken);
+      } else {
+        throw Exception('Failed to get access token: ${response.body}');
+      }
+    } catch (e) {
+      debugPrint('認証プロセス中にエラーが発生しました: $e');
+    } finally {
+      await _linkSubscription?.cancel();
+      _linkSubscription = null;
+    }
+
+    return AuthResult.failure("");
+  }
+
+  
+  Future<Uri> _listenForAppLink() async {
+    final completer = Completer<Uri>();
+    
+    try {
+      final initialLink = await appLinks.getInitialLink();
+      if (initialLink != null && initialLink.queryParameters.containsKey('code')) {
+        debugPrint('初期App Linkからコードを検出: ${initialLink.queryParameters['code']}');
+        completer.complete(initialLink);
+        return completer.future;
+      }
+    } catch (e) {
+      debugPrint('初期App Linkの取得エラー: $e');
+    }
+    
+    _linkSubscription = appLinks.uriLinkStream.listen((Uri uri) {
+      if (!completer.isCompleted && uri.queryParameters.containsKey('code')) {
+        debugPrint('App Linkからコードを検出: ${uri.queryParameters['code']}');
+        completer.complete(uri);
+      }
+    }, onError: (error) {
+      debugPrint('App Linkエラー: $error');
+      if (!completer.isCompleted) {
+        completer.completeError(error);
+      }
+    });
+    
+    return completer.future;
+  }
+  
+  Future<void> _redirectToBrowser(Uri url) async {
+    debugPrint('以下のURLをブラウザで開いてGitHubにログインしてください:');
+    debugPrint(url.toString());
+
+    urlLauncher.launch(
+      url,
+      mode: LaunchMode.externalApplication,
+    );
+  }
+}
+
+class _MockHttpClient extends http.BaseClient {
+  final Future<http.Response> Function(http.Request) mockHandler;
+  
+  _MockHttpClient(this.mockHandler);
+  
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final response = await mockHandler(request as http.Request);
+    
+    return http.StreamedResponse(
+      Stream.value(response.bodyBytes),
+      response.statusCode,
+      headers: response.headers,
+    );
+  }
+}

--- a/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
@@ -10,6 +10,7 @@ import 'package:github_browser/features/github_auth/entities/auth_result.dart';
 import 'package:github_browser/features/github_auth/repositories/github_auth_repository.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+// ignore: depend_on_referenced_packages
 import 'package:http/http.dart' as http;
 import 'package:oauth2/oauth2.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -103,7 +104,7 @@ void main() {
       final streamController = StreamController<Uri>();
       when(mockAppLinks.uriLinkStream).thenAnswer((_) => streamController.stream);
       
-      final httpMock = (request) async {
+      httpMock(request) async {
         if (request.url.toString() == 'https://github.com/login/oauth/access_token') {
           return http.Response(
             '{"access_token": "$testAccessToken", "token_type": "bearer", "scope": "repo,user"}',
@@ -112,7 +113,7 @@ void main() {
           );
         }
         return http.Response('Not found', 404);
-      };
+      }
       
       final testRepository = _TestGithubAuthRepositoryWithHttpMock(
         clientId: testClientId,
@@ -148,7 +149,7 @@ void main() {
       final streamController = StreamController<Uri>();
       when(mockAppLinks.uriLinkStream).thenAnswer((_) => streamController.stream);
       
-      final httpMock = (request) async {
+      httpMock(request) async {
         if (request.url.toString() == 'https://github.com/login/oauth/access_token') {
           return http.Response(
             '{"error": "bad_verification_code"}',
@@ -157,7 +158,7 @@ void main() {
           );
         }
         return http.Response('Not found', 404);
-      };
+      }
       
       final testRepository = _TestGithubAuthRepositoryWithHttpMock(
         clientId: testClientId,
@@ -187,7 +188,7 @@ void main() {
       final initialLink = Uri.parse('$testRedirectUrl?code=initial_code');
       when(mockAppLinks.getInitialLink()).thenAnswer((_) async => initialLink);
       
-      final httpMock = (request) async {
+      httpMock(request) async {
         if (request.url.toString() == 'https://github.com/login/oauth/access_token') {
           return http.Response(
             '{"access_token": "$testAccessToken", "token_type": "bearer", "scope": "repo,user"}',
@@ -196,7 +197,7 @@ void main() {
           );
         }
         return http.Response('Not found', 404);
-      };
+      }
       
       final testRepository = _TestGithubAuthRepositoryWithHttpMock(
         clientId: testClientId,

--- a/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/github_auth_repository_test.dart
@@ -46,7 +46,6 @@ void main() {
       clientSecret: testClientSecret,
       redirectUrl: testRedirectUrl,
       scopes: testScopes,
-      credentialsPath: testCredentialsPath,
       appLinks: mockAppLinks,
       urlLauncher: mockUrlLauncher,
     );
@@ -58,7 +57,6 @@ void main() {
       expect(repository.clientSecret, testClientSecret);
       expect(repository.redirectUrl, Uri.parse(testRedirectUrl));
       expect(repository.scopes, testScopes);
-      expect(repository.credentialsFile, isA<File>());
       expect(repository.appLinks, mockAppLinks);
     });
     
@@ -69,7 +67,6 @@ void main() {
       expect(repository.clientSecret, Env.clientSecret);
       expect(repository.redirectUrl, Uri.parse(Env.redirectUrl));
       expect(repository.scopes, ['repo', 'user']);
-      expect(repository.credentialsFile, isA<File>());
       expect(repository.appLinks, isA<AppLinks>());
     });
     
@@ -81,7 +78,6 @@ void main() {
         clientSecret: testClientSecret,
         redirectUrl: testRedirectUrl,
         scopes: testScopes,
-        credentialsPath: testCredentialsPath,
         appLinks: mockAppLinks,
         urlLauncher: mockUrlLauncher,
         apiKey: testApiKey,
@@ -120,7 +116,6 @@ void main() {
         clientSecret: testClientSecret,
         redirectUrl: testRedirectUrl,
         scopes: testScopes,
-        credentialsPath: testCredentialsPath,
         appLinks: mockAppLinks,
         urlLauncher: mockUrlLauncher,
         httpMock: httpMock,
@@ -165,7 +160,6 @@ void main() {
         clientSecret: testClientSecret,
         redirectUrl: testRedirectUrl,
         scopes: testScopes,
-        credentialsPath: testCredentialsPath,
         appLinks: mockAppLinks,
         urlLauncher: mockUrlLauncher,
         httpMock: httpMock,
@@ -204,7 +198,6 @@ void main() {
         clientSecret: testClientSecret,
         redirectUrl: testRedirectUrl,
         scopes: testScopes,
-        credentialsPath: testCredentialsPath,
         appLinks: mockAppLinks,
         urlLauncher: mockUrlLauncher,
         httpMock: httpMock,
@@ -229,7 +222,6 @@ class _TestGithubAuthRepository extends GithubAuthRepository {
     required String clientSecret,
     required String redirectUrl,
     required List<String> scopes,
-    required String credentialsPath,
     required AppLinks appLinks,
     required UrlLauncher urlLauncher,
     required this.apiKey,
@@ -238,7 +230,6 @@ class _TestGithubAuthRepository extends GithubAuthRepository {
     clientSecret: clientSecret,
     redirectUrl: redirectUrl,
     scopes: scopes,
-    credentialsPath: credentialsPath,
     appLinks: appLinks,
     urlLauncher: urlLauncher,
   );
@@ -261,7 +252,6 @@ class _TestGithubAuthRepositoryWithHttpMock extends GithubAuthRepository {
     required String clientSecret,
     required String redirectUrl,
     required List<String> scopes,
-    required String credentialsPath,
     required AppLinks appLinks,
     required UrlLauncher urlLauncher,
     required this.httpMock,
@@ -270,7 +260,6 @@ class _TestGithubAuthRepositoryWithHttpMock extends GithubAuthRepository {
     clientSecret: clientSecret,
     redirectUrl: redirectUrl,
     scopes: scopes,
-    credentialsPath: credentialsPath,
     appLinks: appLinks,
     urlLauncher: urlLauncher,
   );

--- a/test/unit/features/github_auth/repositories/secure_repository_test.dart
+++ b/test/unit/features/github_auth/repositories/secure_repository_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/github_auth/repositories/secure_repository.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
+
+@GenerateMocks([FlutterSecureStorage])
+import 'secure_repository_test.mocks.dart';
+
+void main() {
+  late GithubSecureRepository repository;
+  late MockFlutterSecureStorage mockSecureStorage;
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    mockSecureStorage = MockFlutterSecureStorage();
+    
+    repository = GithubSecureRepository(
+      storage: mockSecureStorage
+    );
+  });
+
+  group('GithubSecureRepository Tests', () {
+    test('saveTokenは正しいパラメータでセキュアストレージのwriteを呼び出すこと', () async {
+      const String token = 'test_token';
+      when(mockSecureStorage.write(key: anyNamed('key'), value: anyNamed('value')))
+          .thenAnswer((_) => Future.value());
+
+      await repository.saveToken(token);
+
+      verify(mockSecureStorage.write(key: 'github_auth_token', value: token)).called(1);
+    });
+
+    test('getTokenは正しいキーでセキュアストレージのreadを呼び出すこと', () async {
+      const String expectedToken = 'test_token';
+      when(mockSecureStorage.read(key: anyNamed('key')))
+          .thenAnswer((_) => Future.value(expectedToken));
+
+      final result = await repository.getToken();
+
+      expect(result, equals(expectedToken));
+      verify(mockSecureStorage.read(key: 'github_auth_token')).called(1);
+    });
+
+    test('deleteTokenは正しいキーでセキュアストレージのdeleteを呼び出すこと', () async {
+      when(mockSecureStorage.delete(key: anyNamed('key')))
+          .thenAnswer((_) => Future.value());
+
+      await repository.deleteToken();
+
+      verify(mockSecureStorage.delete(key: 'github_auth_token')).called(1);
+    });
+  });
+}

--- a/test/widget/features/github_auth/components/auth_wrapper_test.dart
+++ b/test/widget/features/github_auth/components/auth_wrapper_test.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/features/github_auth/components/auth_wrapper.dart';
+import 'package:github_browser/features/github_auth/entities/auth_result.dart';
+import 'package:github_browser/features/github_auth/repositories/github_auth_repository.dart';
+import 'package:github_browser/features/github_auth/repositories/secure_repository.dart';
+import 'package:github_browser/pages/search_page.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+@GenerateMocks([GithubAuthRepository, GithubSecureRepository])
+import 'auth_wrapper_test.mocks.dart';
+
+class TestApp extends StatelessWidget {
+  final Widget child;
+
+  const TestApp({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    );
+  }
+}
+
+class MockSearchPage extends StatelessWidget {
+  final String token;
+
+  const MockSearchPage({super.key, required this.token});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Search Page')),
+      body: Center(child: Text('Authenticated with token: $token')),
+    );
+  }
+}
+
+void main() {
+  late MockGithubAuthRepository mockAuthRepository;
+  late MockGithubSecureRepository mockSecureRepository;
+
+  setUp(() {
+    mockAuthRepository = MockGithubAuthRepository();
+    mockSecureRepository = MockGithubSecureRepository();
+  });
+
+  Widget createAuthWrapper() {
+    return TestApp(
+      child: AuthWrapper(
+        authRepository: mockAuthRepository,
+        secureRepository: mockSecureRepository,
+      ),
+    );
+  }
+
+  group('AuthWrapper Widget Tests', () {
+    testWidgets('トークンがない場合はSignInPageを表示すること',
+        (WidgetTester tester) async {
+
+      when(mockSecureRepository.getToken()).thenAnswer((_) => Future.value(null));
+
+      await tester.pumpWidget(createAuthWrapper());
+      
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SignInPage), findsOneWidget);
+      expect(find.byIcon(Icons.login), findsOneWidget);
+    });
+
+    testWidgets('getTokenが例外をスローした場合はエラーメッセージを表示すること',
+        (WidgetTester tester) async {
+      when(mockSecureRepository.getToken())
+          .thenAnswer((_) => Future.error('Failed to get token'));
+
+      await tester.pumpWidget(createAuthWrapper());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SignInPage), findsOneWidget);
+      expect(find.text('Failed to get token'), findsOneWidget);
+    });
+
+  testWidgets('ボタンが押されたときにサインインが成功すること', 
+      (WidgetTester tester) async {
+    when(mockSecureRepository.getToken()).thenAnswer((_) => Future.value(null));
+    
+    final completer = Completer<AuthResult>();
+    when(mockAuthRepository.signIn()).thenAnswer((_) => completer.future);
+
+    await tester.pumpWidget(createAuthWrapper());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.login));
+    await tester.pump();
+    
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    
+    completer.complete(AuthResult.success('new_token'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SearchPage), findsOneWidget);
+  });
+
+    testWidgets('サインインが失敗した場合はエラーメッセージを表示すること',
+        (WidgetTester tester) async {
+      when(mockSecureRepository.getToken()).thenAnswer((_) => Future.value(null));
+      
+      when(mockAuthRepository.signIn()).thenAnswer(
+          (_) => Future.value(AuthResult.failure('Auth failed')));
+
+      await tester.pumpWidget(createAuthWrapper());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.login));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Auth failed'), findsOneWidget);
+    });
+
+    testWidgets('サインインが例外をスローした場合はエラーメッセージを表示すること',
+        (WidgetTester tester) async {
+      when(mockSecureRepository.getToken()).thenAnswer((_) => Future.value(null));
+      
+      when(mockAuthRepository.signIn())
+          .thenAnswer((_) => Future.error('Network error'));
+
+      await tester.pumpWidget(createAuthWrapper());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.login));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Network error'), findsOneWidget);
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   flutter_secure_storage_windows
   url_launcher_windows
 )


### PR DESCRIPTION
## 対応イシュー
https://github.com/Rerurate514/github_browser/issues/13

## 実施タスク
- [x] Github認証ができ、tokenを取得できること

## 実施内容
- SecureRepositryクラスの作成
- GithubAuthRepositoryクラスの作成
- AuthResultエンティティクラスの作成
- AuthWrapperコンポーネントの作成
- 上記４項目に対してテストを作成
- SearchPageにtokenを渡すように調整

## 備考
資格情報(credentials.json)は保存せずに認証フローを構築