### PR TITLE
info_chipsがアプリ幅を超えてしまう問題の修正とテスト作成

### DIFF
--- a/lib/features/repo_search/components/repo_list_item.dart
+++ b/lib/features/repo_search/components/repo_list_item.dart
@@ -50,21 +50,6 @@ class RepositoryListItem extends StatelessWidget {
                     icon: Icons.code,
                     label: repository.projectLanguage,
                   ),
-                  const SizedBox(width: 8),
-                  InfoChip(
-                    icon: Icons.star,
-                    label: '${repository.starCount}',
-                  ),
-                  const SizedBox(width: 8),
-                  InfoChip(
-                    icon: Icons.call_split,
-                    label: '${repository.forkCount}',
-                  ),
-                  const SizedBox(width: 8),
-                  InfoChip(
-                    icon: Icons.error_outline,
-                    label: '${repository.issueCount}',
-                  ),
                 ],
               ),
             ],

--- a/test/widget/core/components/search_field_test.dart
+++ b/test/widget/core/components/search_field_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:github_browser/core/components/search_field.dart';
+
+void main() {
+  group('SearchField Widget Tests', () {
+    testWidgets('検索フィールドが正しくレンダリングされること', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchField(
+              onSearch: (_) {},
+              hint: 'リポジトリを検索',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+      expect(find.text('リポジトリを検索'), findsOneWidget);
+    });
+
+    testWidgets('テキスト入力時にonSearchが呼ばれること', (WidgetTester tester) async {
+      String searchedText = '';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchField(
+              onSearch: (text) {
+                searchedText = text;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'flutter');
+      await tester.pump();
+
+      expect(searchedText, 'flutter');
+    });
+
+    testWidgets('クリアボタンをタップするとテキストがクリアされること', (WidgetTester tester) async {
+      String searchedText = '';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchField(
+              onSearch: (text) {
+                searchedText = text;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'flutter');
+      await tester.pump();
+      expect(searchedText, 'flutter');
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      expect(find.text('flutter'), findsNothing);
+      expect(searchedText, '');
+    });
+
+    testWidgets('検索ボタンを押したときにonSearchが呼ばれること', (WidgetTester tester) async {
+      String searchedText = '';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchField(
+              onSearch: (text) {
+                searchedText = text;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'flutter');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pump();
+
+      expect(searchedText, 'flutter');
+    });
+
+    testWidgets('コントローラーが正常に動作すること', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchField(
+              onSearch: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final TextField textField = tester.widget<TextField>(find.byType(TextField));
+      final TextEditingController controller = textField.controller!;
+
+      await tester.enterText(find.byType(TextField), 'flutter');
+      await tester.pump();
+
+      expect(controller.text, 'flutter');
+    });
+
+    testWidgets('デフォルトのヒントテキストが表示されること', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SearchField(
+              onSearch: (_) {},
+
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('検索'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## 実施タスク
- [x] info_chipに記載される文字列が長い場合、アプリの幅を超える問題を修正
- [x] SearchFieldコンポーネントのテスト作成 

## 実施内容
- repo_list_itemコンポーネントのinfo_chips数を一つに変更
- SearchFieldコンポーネントのテスト作成 

## 備考
