### PR TITLE
デプロイ設定の追加

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -31,7 +31,11 @@ jobs:
 
     # リモートリポジトリでGitHub Secretsから.envファイルを動的に作成
     - name: Create .env
-      run: echo "API_KEY=${{ secrets.API_KEY }}" >> .env
+      run: |
+        echo "API_KEY=${{ secrets.API_KEY }}" >> .env
+        echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
+        echo "CLIENT_SECRET=${{ secrets.CLIENT_SECRET }}" >> .env
+        echo "REDIRECT_URL=${{ secrets.REDIRECT_URL }}" >> .env
 
     - name: Generate code with build_runner
       run: flutter pub run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -58,22 +58,22 @@ jobs:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ~/coverage/lcov.info
 
-    # - name: Decode keystore
-    #   run: echo "${{ secrets.SIGNING_KEY }}" | base64 -d > android/app/key.jks
-    # 
-    # - name: Create key.properties
-    #   run: |
-    #     echo "storePassword=${{ secrets.KEY_STORE_PASSWORD }}" > android/key.properties
-    #     echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
-    #     echo "keyAlias=${{ secrets.ALIAS }}" >> android/key.properties
-    #     echo "storeFile=key.jks" >> android/key.properties
-    # 
-    # - name: Build APK (Android)
-    #   run: flutter build apk --release
-    # 
-    # - name: "Deploy apk 🚀"
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: release-apk
-    #     path: build/app/outputs/flutter-apk/app-release.apk
-    #     retention-days: 7
+    - name: Decode keystore
+      run: echo "${{ secrets.SIGNING_KEY }}" | base64 -d > android/app/key.jks
+    
+    - name: Create key.properties
+      run: |
+        echo "storePassword=${{ secrets.KEY_STORE_PASSWORD }}" > android/key.properties
+        echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
+        echo "keyAlias=${{ secrets.ALIAS }}" >> android/key.properties
+        echo "storeFile=key.jks" >> android/key.properties
+    
+    - name: Build APK (Android)
+      run: flutter build apk --release
+    
+    - name: "Deploy apk 🚀"
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-apk
+        path: build/app/outputs/flutter-apk/app-release.apk
+        retention-days: 7

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
-        java-version: '12.x'
+        java-version: '17.x'
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v1

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,17 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -30,11 +39,22 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = if (keystoreProperties["storeFile"] != null) {
+                file(keystoreProperties["storeFile"] as String)
+            } else {
+                null
+            }
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
+    
     buildTypes {
-        release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }


### PR DESCRIPTION
## 実施タスク
- [x] ワークフロー上でアプリの生成からデプロイまでを追加 

## 実施内容
- [x] Androidアプリの生成に必要なkey.jks情報を追記

## 備考
必要な資格情報はGithub.secretに追加
以下のワークフローにてArtifatsとしてapkが格納されています。
https://github.com/Rerurate514/github_browser/actions/runs/14489730173